### PR TITLE
Dual docker

### DIFF
--- a/core/client/client/cocoon.go
+++ b/core/client/client/cocoon.go
@@ -271,7 +271,7 @@ func ListCocoons(showAll, jsonFormatted bool) error {
 
 	tableData := [][]string{}
 	for _, cocoon := range cocoons {
-		if !showAll && !util.InStringSlice([]string{api.CocoonStatusStarted, api.CocoonStatusRunning}, cocoon.Status) {
+		if !showAll && !util.InStringSlice([]string{api.CocoonStatusStarted, api.CocoonStatusBuilding, api.CocoonStatusRunning}, cocoon.Status) {
 			continue
 		}
 		created, _ := time.Parse(time.RFC3339, cocoon.CreatedAt)

--- a/core/client/cmd/info.go
+++ b/core/client/cmd/info.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/ncodes/cocoon/core/client/client"
+	"github.com/spf13/cobra"
+)
+
+// infoCmd represents the info command
+var infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Display system-wide information",
+	Long:  `Display system-wide information`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		userSession, err := client.GetUserSessionToken()
+		if err != nil {
+			return
+		}
+
+		fmt.Println(`User:
+  Email: ` + userSession.Email + `
+
+Client:
+  Version:     0.0.5
+  API version: 0.0.5
+  Go version:  go1.8
+  
+Core:
+  API:         https://rpc.ellcrys.co
+  Version:     0.0.5
+  API version: 0.0.5
+  Go version:  go1.8
+		`)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(infoCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// infoCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// infoCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}

--- a/core/client/cmd/root.go
+++ b/core/client/cmd/root.go
@@ -17,7 +17,14 @@ var RootCmd = &cobra.Command{
 	Long:  `A blockchain-inspired, shared ledger and smart contract platform`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
-	//	Run: func(cmd *cobra.Command, args []string) { },
+	Run: func(cmd *cobra.Command, args []string) {
+		showVersion, _ := cmd.Flags().GetBool("version")
+		if showVersion {
+			fmt.Println("Cocoon version 0.0.5")
+			return
+		}
+		cmd.Usage()
+	},
 }
 
 // Execute adds all child commands to the root command sets flags appropriately.
@@ -30,6 +37,7 @@ func Execute() {
 }
 
 func init() {
+	RootCmd.Flags().BoolP("version", "v", false, "Display the Cocoon version information")
 	cobra.OnInitialize(initConfig)
 }
 

--- a/core/client/cmd/version.go
+++ b/core/client/cmd/version.go
@@ -1,0 +1,55 @@
+// Copyright © 2017 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show the Cocoon version information",
+	Long:  `Show the Cocoon version information`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(`Client:
+  Version:     0.0.5
+  API version: 0.0.5
+  Go version:  go1.8
+  
+Core:
+  Version:     0.0.5
+  API version: 0.0.5
+  Go version:  go1.8
+		`)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// versionCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// versionCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}

--- a/core/cmd/connector.go
+++ b/core/cmd/connector.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 	"syscall"
 
-	"net"
-
 	"github.com/ellcrys/util"
 	"github.com/ncodes/cocoon/core/common"
 	"github.com/ncodes/cocoon/core/config"
@@ -100,7 +98,7 @@ var connectorCmd = &cobra.Command{
 		log.Infof("Ready to launch cocoon code with id = %s", req.ID)
 
 		connectorRPCAddr := scheduler.Getenv("ADDR_RPC", defaultConnectorRPCAPI)
-		cocoonCodeRPCAddr := net.JoinHostPort("", scheduler.Getenv("PORT_code_RPC", "8004"))
+		cocoonCodeRPCAddr := scheduler.Getenv("ADDR_code_RPC", ":8004")
 
 		cn := connector.NewConnector(req, waitCh)
 		cn.SetAddrs(connectorRPCAddr, cocoonCodeRPCAddr)

--- a/core/cmd/connector.go
+++ b/core/cmd/connector.go
@@ -99,8 +99,8 @@ var connectorCmd = &cobra.Command{
 		}
 		log.Infof("Ready to launch cocoon code with id = %s", req.ID)
 
-		connectorRPCAddr := scheduler.Getenv("ADDR_CONNECTOR_RPC", defaultConnectorRPCAPI)
-		cocoonCodeRPCAddr := net.JoinHostPort("", scheduler.Getenv("PORT_COCOON_RPC", "8004"))
+		connectorRPCAddr := scheduler.Getenv("ADDR_RPC", defaultConnectorRPCAPI)
+		cocoonCodeRPCAddr := net.JoinHostPort("", scheduler.Getenv("PORT_code_RPC", "8004"))
 
 		cn := connector.NewConnector(req, waitCh)
 		cn.SetAddrs(connectorRPCAddr, cocoonCodeRPCAddr)

--- a/core/connector/connector.go
+++ b/core/connector/connector.go
@@ -606,12 +606,12 @@ func (cn *Connector) getDefaultFirewall() string {
 
 	return strings.TrimSpace(`iptables -F && 
 	        iptables -P OUTPUT ACCEPT &&
-			iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT &&
 	        iptables -I INPUT 1 -i lo -j ACCEPT && 
+			iptables -A INPUT -p tcp -s ` + connectorRPCIP + ` --dport ` + cocoonCodeRPCPort + ` -j ACCEPT &&
+			iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT &&
 			iptables -A OUTPUT -p udp --dport 53 -j ACCEPT &&
 			iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT &&
 			iptables -A OUTPUT -p tcp -d ` + connectorRPCIP + ` --dport ` + connectorRPCPort + ` -j ACCEPT &&
-			iptables -A INPUT -p tcp -s ` + connectorRPCIP + ` --dport ` + cocoonCodeRPCPort + ` -j ACCEPT &&
 			iptables -A OUTPUT -p tcp -d google.com --dport 80 -j ACCEPT && 
 			iptables -P INPUT DROP && 
 			iptables -P FORWARD DROP &&

--- a/core/connector/connector.go
+++ b/core/connector/connector.go
@@ -547,7 +547,7 @@ func (cn *Connector) execInContainer(container *docker.APIContainers, name strin
 // build starts up the container and builds the cocoon code
 // according to the build script provided by the language.
 func (cn *Connector) build(container *docker.APIContainers, lang Language) error {
-	cmd := []string{"bash", "-c", "pwd"}
+	cmd := []string{"bash", "-c", lang.GetBuildScript()}
 	return cn.execInContainer(container, "BUILD", cmd, false, buildLog, func(state string, val interface{}) error {
 		switch state {
 		case "before":

--- a/core/connector/connector.go
+++ b/core/connector/connector.go
@@ -605,17 +605,14 @@ func (cn *Connector) getDefaultFirewall() string {
 	connectorRPCIP, connectorRPCPort, _ := net.SplitHostPort(cn.connectorRPCAddr)
 
 	return strings.TrimSpace(`iptables -F && 
-	        iptables -P OUTPUT ACCEPT &&
-	        iptables -I INPUT 1 -i lo -j ACCEPT && 
+	        iptables -P INPUT DROP && 
+			iptables -P FORWARD DROP &&
+			iptables -P OUTPUT DROP
 			iptables -A INPUT -p tcp -s ` + connectorRPCIP + ` --dport ` + cocoonCodeRPCPort + ` -j ACCEPT &&
 			iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT &&
 			iptables -A OUTPUT -p udp --dport 53 -j ACCEPT &&
 			iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT &&
-			iptables -A OUTPUT -p tcp -d ` + connectorRPCIP + ` --dport ` + connectorRPCPort + ` -j ACCEPT &&
-			iptables -A OUTPUT -p tcp -d google.com --dport 80 -j ACCEPT && 
-			iptables -P INPUT DROP && 
-			iptables -P FORWARD DROP &&
-			iptables -P OUTPUT DROP`)
+			iptables -A OUTPUT -p tcp -d ` + connectorRPCIP + ` --dport ` + connectorRPCPort + ` -j ACCEPT`)
 }
 
 // configFirewall configures the container firewall.

--- a/core/connector/connector.go
+++ b/core/connector/connector.go
@@ -165,8 +165,8 @@ func (cn *Connector) prepareContainer(lang Language) (*docker.APIContainers, err
 	container, err := cn.getContainer(containerName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check whether cocoon code is already active. %s ", err.Error())
-	} else if container != nil {
-		return nil, fmt.Errorf("cocoon code already exists on a container")
+	} else if container == nil {
+		return nil, fmt.Errorf("cocoon code container has not been started")
 	}
 
 	_, err = cn.fetchSource(lang)

--- a/core/connector/connector.go
+++ b/core/connector/connector.go
@@ -600,20 +600,18 @@ func (cn *Connector) run(container *docker.APIContainers, lang Language) error {
 // getDefaultFirewall returns the default firewall rules
 // for a cocoon container.
 func (cn *Connector) getDefaultFirewall() string {
-
 	_, cocoonCodeRPCPort, _ := net.SplitHostPort(cn.cocoonCodeRPCAddr)
 	connectorRPCIP, connectorRPCPort, _ := net.SplitHostPort(cn.connectorRPCAddr)
-
 	return strings.TrimSpace(`iptables -F && 
 			iptables -P INPUT DROP && 
 			iptables -P FORWARD DROP &&
 			iptables -P OUTPUT DROP &&
 			iptables -A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT &&
-			iptables -A OUTPUT -p tcp -d ` + connectorRPCIP + ` --dport ` + connectorRPCPort + ` -j ACCEPT
+			iptables -A OUTPUT -p tcp -d ` + connectorRPCIP + ` --dport ` + connectorRPCPort + ` -j ACCEPT &&
 			iptables -A OUTPUT -p udp --dport 53 -j ACCEPT && 
 			iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT &&
 			iptables -A INPUT -p tcp -s ` + connectorRPCIP + ` --dport ` + cocoonCodeRPCPort + ` -j ACCEPT 
-			`)
+		`)
 }
 
 // configFirewall configures the container firewall.

--- a/core/connector/connector.go
+++ b/core/connector/connector.go
@@ -605,14 +605,15 @@ func (cn *Connector) getDefaultFirewall() string {
 	connectorRPCIP, connectorRPCPort, _ := net.SplitHostPort(cn.connectorRPCAddr)
 
 	return strings.TrimSpace(`iptables -F && 
-	        iptables -P INPUT DROP && 
+			iptables -P INPUT DROP && 
 			iptables -P FORWARD DROP &&
-			iptables -P OUTPUT DROP
-			iptables -A INPUT -p tcp -s ` + connectorRPCIP + ` --dport ` + cocoonCodeRPCPort + ` -j ACCEPT &&
+			iptables -P OUTPUT DROP &&
+			iptables -A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT &&
+			iptables -A OUTPUT -p tcp -d ` + connectorRPCIP + ` --dport ` + connectorRPCPort + ` -j ACCEPT
+			iptables -A OUTPUT -p udp --dport 53 -j ACCEPT && 
 			iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT &&
-			iptables -A OUTPUT -p udp --dport 53 -j ACCEPT &&
-			iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT &&
-			iptables -A OUTPUT -p tcp -d ` + connectorRPCIP + ` --dport ` + connectorRPCPort + ` -j ACCEPT`)
+			iptables -A INPUT -p tcp -s ` + connectorRPCIP + ` --dport ` + cocoonCodeRPCPort + ` -j ACCEPT 
+			`)
 }
 
 // configFirewall configures the container firewall.

--- a/core/connector/connector.go
+++ b/core/connector/connector.go
@@ -583,8 +583,8 @@ func (cn *Connector) run(container *docker.APIContainers, lang Language) error {
 		case "before":
 			log.Info("Starting cocoon code")
 		case "after":
-			cn.setStatus(api.CocoonStatusRunning)
 			go cn.healthCheck.Start()
+			cn.setStatus(api.CocoonStatusRunning)
 			return nil
 		case "end":
 			cn.setStatus(api.CocoonStatusStopped)

--- a/core/connector/connector.go
+++ b/core/connector/connector.go
@@ -611,7 +611,7 @@ func (cn *Connector) getDefaultFirewall() string {
 			iptables -A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT &&
 			iptables -A OUTPUT -p tcp -d ` + connectorRPCIP + ` --dport ` + connectorRPCPort + ` -j ACCEPT
 			iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT &&
-			iptables -A INPUT -p tcp --dport ` + cocoonCodeRPCPort + ` -j ACCEPT 
+			iptables -A INPUT -p tcp -s ` + connectorRPCIP + ` --dport ` + cocoonCodeRPCPort + ` -j ACCEPT 
 			dnsIPs="$(cat /etc/resolv.conf | grep 'nameserver' | cut -c12-)" &&
 			for ip in $dnsIPs;
 			do 

--- a/core/connector/connector.go
+++ b/core/connector/connector.go
@@ -99,6 +99,8 @@ func (cn *Connector) Launch(connectorRPCAddr, cocoonCodeRPCAddr string) {
 		return
 	}
 
+	return
+
 	newContainer, err := cn.prepareContainer(cn.req, lang)
 	if err != nil {
 		log.Error(err.Error())

--- a/core/connector/connector.go
+++ b/core/connector/connector.go
@@ -547,7 +547,7 @@ func (cn *Connector) execInContainer(container *docker.APIContainers, name strin
 // build starts up the container and builds the cocoon code
 // according to the build script provided by the language.
 func (cn *Connector) build(container *docker.APIContainers, lang Language) error {
-	cmd := []string{"bash", "-c", lang.GetBuildScript()}
+	cmd := []string{"bash", "-c", "pwd"}
 	return cn.execInContainer(container, "BUILD", cmd, false, buildLog, func(state string, val interface{}) error {
 		switch state {
 		case "before":

--- a/core/connector/connector.go
+++ b/core/connector/connector.go
@@ -75,7 +75,7 @@ func (cn *Connector) Launch(connectorRPCAddr, cocoonCodeRPCAddr string) {
 
 	dckClient = client
 	cn.monitor.SetDockerClient(dckClient)
-	cn.healthCheck = NewHealthChecker("127.0.0.1"+cn.cocoonCodeRPCAddr, cn.cocoonUnresponsive)
+	cn.healthCheck = NewHealthChecker(cn.cocoonCodeRPCAddr, cn.cocoonUnresponsive)
 	go cn.ordererDiscovery.Discover()
 
 	// No need downloading, building and starting a cocoon code

--- a/core/connector/connector.go
+++ b/core/connector/connector.go
@@ -605,12 +605,14 @@ func (cn *Connector) getDefaultFirewall() string {
 	connectorRPCIP, connectorRPCPort, _ := net.SplitHostPort(cn.connectorRPCAddr)
 
 	return strings.TrimSpace(`iptables -F && 
+	        iptables -P OUTPUT ACCEPT &&
+			iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT &&
 	        iptables -I INPUT 1 -i lo -j ACCEPT && 
 			iptables -A OUTPUT -p udp --dport 53 -j ACCEPT &&
 			iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT &&
 			iptables -A OUTPUT -p tcp -d ` + connectorRPCIP + ` --dport ` + connectorRPCPort + ` -j ACCEPT &&
-			iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT &&
 			iptables -A INPUT -p tcp -s ` + connectorRPCIP + ` --dport ` + cocoonCodeRPCPort + ` -j ACCEPT &&
+			iptables -A OUTPUT -p tcp -d google.com --dport 80 -j ACCEPT && 
 			iptables -P INPUT DROP && 
 			iptables -P FORWARD DROP &&
 			iptables -P OUTPUT DROP`)

--- a/core/connector/language_go.go
+++ b/core/connector/language_go.go
@@ -79,7 +79,7 @@ func (g *Go) GetDownloadDestination() string {
 func (g *Go) GetCopyDestination() string {
 	u, _ := urlx.Parse(g.req.URL)
 	repoID := strings.Trim(u.Path, "/")
-	return path.Join(g.imgGoPath, "src/github.com/", strings.Split(repoID, "/")[0])
+	return path.Join(g.imgGoPath, "src/github.com/", repoID)
 }
 
 // GetSourceRootDir returns the root directory of the cocoon source code

--- a/core/connector/language_go.go
+++ b/core/connector/language_go.go
@@ -125,7 +125,11 @@ func (g *Go) GetBuildScript() string {
 		}
 	}
 
-	return strings.Join(util.RemoveEmptyInStringSlice([]string{pkgFetchCmd, "go build -v -o /bin/ccode"}), " && ")
+	return strings.Join(util.RemoveEmptyInStringSlice([]string{
+		fmt.Sprintf("cd %s", g.GetSourceRootDir()), // cd into cocoon source root directory
+		pkgFetchCmd,                                // run the package manager build command
+		"go build -v -o /bin/ccode",                // build the cocoon code binary
+	}), " && ")
 }
 
 // GetRunScript returns the script required to start the

--- a/core/connector/language_go.go
+++ b/core/connector/language_go.go
@@ -79,7 +79,7 @@ func (g *Go) GetDownloadDestination() string {
 func (g *Go) GetCopyDestination() string {
 	u, _ := urlx.Parse(g.req.URL)
 	repoID := strings.Trim(u.Path, "/")
-	return path.Join(g.imgGoPath, "src/github.com/", repoID)
+	return path.Join(g.imgGoPath, "src/github.com/", strings.Split(repoID, "/")[0])
 }
 
 // GetSourceRootDir returns the root directory of the cocoon source code

--- a/core/connector/language_go.go
+++ b/core/connector/language_go.go
@@ -67,7 +67,7 @@ func (g *Go) SetRunEnv(env map[string]string) {
 }
 
 // GetDownloadDestination returns the location to save
-// the downloaded go cocoon code to.
+// the downloaded go cocoon code source on the connector
 func (g *Go) GetDownloadDestination() string {
 	u, _ := urlx.Parse(g.req.URL)
 	repoID := strings.Trim(u.Path, "/")
@@ -79,7 +79,7 @@ func (g *Go) GetDownloadDestination() string {
 func (g *Go) GetCopyDestination() string {
 	u, _ := urlx.Parse(g.req.URL)
 	repoID := strings.Trim(u.Path, "/")
-	return path.Join(g.imgGoPath, "src/github.com/", strings.Split(repoID, "/")[0])
+	return path.Join(g.imgGoPath, "src/github.com/", repoID)
 }
 
 // GetSourceRootDir returns the root directory of the cocoon source code

--- a/core/connector/stream_logger.go
+++ b/core/connector/stream_logger.go
@@ -50,7 +50,6 @@ func (ls *LogStreamer) Start() error {
 	for ls.stopRead == false {
 		bs, err := ioutil.ReadAll(ls.writer.(*bytes.Buffer))
 		if err != nil {
-			ls.mutex.Unlock()
 			return err
 		}
 

--- a/core/connector/stream_logger.go
+++ b/core/connector/stream_logger.go
@@ -8,8 +8,6 @@ import (
 
 	"time"
 
-	"sync"
-
 	logging "github.com/op/go-logging"
 )
 
@@ -21,7 +19,6 @@ type LogStreamer struct {
 	writer   io.Writer
 	logger   *logging.Logger
 	stopRead bool
-	mutex    sync.Mutex
 }
 
 // NewLogStreamer reads from a stream and logs to stdout
@@ -29,7 +26,6 @@ func NewLogStreamer() *LogStreamer {
 	return &LogStreamer{
 		writer: bytes.NewBuffer(nil),
 		logger: logStreamLogger,
-		mutex:  sync.Mutex{},
 	}
 }
 
@@ -52,7 +48,6 @@ func (ls *LogStreamer) Stop() {
 // Start starts reading the writer and logging its data
 func (ls *LogStreamer) Start() error {
 	for ls.stopRead == false {
-		ls.mutex.Lock()
 		bs, err := ioutil.ReadAll(ls.writer.(*bytes.Buffer))
 		if err != nil {
 			ls.mutex.Unlock()
@@ -61,7 +56,6 @@ func (ls *LogStreamer) Start() error {
 
 		// reset the writer
 		ls.writer.(*bytes.Buffer).Reset()
-		ls.mutex.Unlock()
 
 		if len(bs) > 0 {
 			ls.logger.Info(string(bs))

--- a/core/main.go
+++ b/core/main.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"time"
 
+	_ "net/http/pprof"
+
 	"github.com/franela/goreq"
 	"github.com/ncodes/cocoon/core/cmd"
 	"github.com/ncodes/cocoon/core/config"
@@ -22,16 +24,19 @@ func init() {
 }
 
 func main() {
-	defer profile.Start().Stop()
+	defer profile.Start(profile.MemProfile).Stop()
 
 	go func() {
 		go func() {
 			log.Info(http.ListenAndServe("localhost:6060", nil).Error())
 		}()
 
-		var mem runtime.MemStats
-		runtime.ReadMemStats(&mem)
-		log.Infof("Alloc: %s, Total Alloc: %s, HeapAlloc: %s, HeapSys: %s", mem.Alloc, mem.TotalAlloc, mem.HeapAlloc, mem.HeapSys)
+		for {
+			var mem runtime.MemStats
+			runtime.ReadMemStats(&mem)
+			log.Infof("Alloc: %d, Total Alloc: %d, HeapAlloc: %d, HeapSys: %d", mem.Alloc, mem.TotalAlloc, mem.HeapAlloc, mem.HeapSys)
+			time.Sleep(10 * time.Second)
+		}
 	}()
 
 	if err := cmd.RootCmd.Execute(); err != nil {

--- a/core/main.go
+++ b/core/main.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"net/http"
 	"os"
-	"runtime"
 	"time"
 
 	_ "net/http/pprof"
@@ -12,7 +10,6 @@ import (
 	"github.com/ncodes/cocoon/core/cmd"
 	"github.com/ncodes/cocoon/core/config"
 	"github.com/op/go-logging"
-	"github.com/pkg/profile"
 )
 
 var log *logging.Logger
@@ -24,20 +21,20 @@ func init() {
 }
 
 func main() {
-	defer profile.Start(profile.MemProfile).Stop()
+	// defer profile.Start(profile.MemProfile).Stop()
 
-	go func() {
-		go func() {
-			log.Info(http.ListenAndServe("localhost:6060", nil).Error())
-		}()
+	// go func() {
+	// 	go func() {
+	// 		log.Info(http.ListenAndServe("localhost:6060", nil).Error())
+	// 	}()
 
-		for {
-			var mem runtime.MemStats
-			runtime.ReadMemStats(&mem)
-			log.Infof("Alloc: %d, Total Alloc: %d, HeapAlloc: %d, HeapSys: %d", mem.Alloc, mem.TotalAlloc, mem.HeapAlloc, mem.HeapSys)
-			time.Sleep(10 * time.Second)
-		}
-	}()
+	// 	for {
+	// 		var mem runtime.MemStats
+	// 		runtime.ReadMemStats(&mem)
+	// 		log.Infof("Alloc: %d, Total Alloc: %d, HeapAlloc: %d, HeapSys: %d", mem.Alloc, mem.TotalAlloc, mem.HeapAlloc, mem.HeapSys)
+	// 		time.Sleep(10 * time.Second)
+	// 	}
+	// }()
 
 	if err := cmd.RootCmd.Execute(); err != nil {
 		log.Error(err.Error())

--- a/core/main.go
+++ b/core/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ncodes/cocoon/core/cmd"
 	"github.com/ncodes/cocoon/core/config"
 	"github.com/op/go-logging"
+	"github.com/pkg/profile"
 )
 
 var log *logging.Logger
@@ -19,6 +20,7 @@ func init() {
 }
 
 func main() {
+	defer profile.Start().Stop()
 	if err := cmd.RootCmd.Execute(); err != nil {
 		log.Error(err.Error())
 		os.Exit(-1)

--- a/core/main.go
+++ b/core/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"net/http"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/franela/goreq"
@@ -21,6 +23,17 @@ func init() {
 
 func main() {
 	defer profile.Start().Stop()
+
+	go func() {
+		go func() {
+			log.Info(http.ListenAndServe("localhost:6060", nil))
+		}()
+
+		var mem runtime.MemStats
+		runtime.ReadMemStats(&mem)
+		log.Infof("Alloc: %s, Total Alloc: %s, HeapAlloc: %s, HeapSys: %s", mem.Alloc, mem.TotalAlloc, mem.HeapAlloc, mem.HeapSys)
+	}()
+
 	if err := cmd.RootCmd.Execute(); err != nil {
 		log.Error(err.Error())
 		os.Exit(-1)

--- a/core/main.go
+++ b/core/main.go
@@ -26,7 +26,7 @@ func main() {
 
 	go func() {
 		go func() {
-			log.Info(http.ListenAndServe("localhost:6060", nil))
+			log.Info(http.ListenAndServe("localhost:6060", nil).Error())
 		}()
 
 		var mem runtime.MemStats

--- a/core/runtime/golang/runtime.go
+++ b/core/runtime/golang/runtime.go
@@ -109,12 +109,13 @@ func Run(cc CocoonCode) {
 
 	serverDone = make(chan bool, 1)
 
-	lis, err := net.Listen("tcp", fmt.Sprintf("%s", serverAddr))
+	bindPort := strings.Split(serverAddr, ":")[1]
+	lis, err := net.Listen("tcp", net.JoinHostPort("", bindPort))
 	if err != nil {
-		log.Fatalf("failed to listen on port=%s", strings.Split(serverAddr, ":")[1])
+		log.Fatalf("failed to listen on port=%s", bindPort)
 	}
 
-	log.Infof("Started stub service at port=%s", strings.Split(serverAddr, ":")[1])
+	log.Infof("Started stub service at port=%s", bindPort)
 	server := grpc.NewServer()
 	proto.RegisterStubServer(server, defaultServer)
 	go startServer(server, lis)

--- a/core/scheduler/nomad.go
+++ b/core/scheduler/nomad.go
@@ -117,8 +117,6 @@ func (sc *Nomad) Deploy(jobID, lang, url, tag, buildParams, linkID, memory, cpuS
 	job.GetSpec().TaskGroups[0].Tasks[0].Env["COCOON_CODE_LANG"] = lang
 	job.GetSpec().TaskGroups[0].Tasks[0].Env["COCOON_BUILD_PARAMS"] = buildParams
 	job.GetSpec().TaskGroups[0].Tasks[0].Env["COCOON_DISK_LIMIT"] = strconv.Itoa(SupportedDiskSpace[cpuShare])
-	job.GetSpec().TaskGroups[0].Tasks[0].Env["ALLOC_MEMORY"] = strconv.Itoa(SupportedMemory[memory])
-	job.GetSpec().TaskGroups[0].Tasks[0].Env["ALLOC_CPU_SHARE"] = strconv.Itoa(SupportedCPUShares[cpuShare])
 
 	// if cocoon linkID is provided, set env variable and also add id to
 	// the service tag. This will allow us use discover the link via consul service discovery.

--- a/core/scheduler/nomad.go
+++ b/core/scheduler/nomad.go
@@ -109,7 +109,7 @@ func (sc *Nomad) Deploy(jobID, lang, url, tag, buildParams, linkID, memory, cpuS
 		buildParams = crypto.ToBase64([]byte(buildParams))
 	}
 
-	job := NewJob("master", jobID, 1)
+	job := NewJob("dual-docker", jobID, 1)
 	job.GetSpec().Region = "global"
 	job.GetSpec().Datacenters = []string{"dc1"}
 	job.GetSpec().TaskGroups[0].Tasks[0].Env["COCOON_CODE_URL"] = url

--- a/core/scheduler/nomad_job.go
+++ b/core/scheduler/nomad_job.go
@@ -225,7 +225,7 @@ func NewJob(connectorVersion, id string, count int) *NomadJob {
 							KillTimeout: 10000000000,
 							Resources: Resources{
 								CPU:      100,
-								MemoryMB: 512,
+								MemoryMB: 1024,
 								DiskMB:   800,
 								IOPS:     0,
 								Networks: []Network{
@@ -260,7 +260,7 @@ func NewJob(connectorVersion, id string, count int) *NomadJob {
 							Artifacts: []Artifact{},
 							Resources: Resources{
 								CPU:      100,
-								MemoryMB: 512,
+								MemoryMB: 1024,
 								DiskMB:   800,
 								IOPS:     0,
 								Networks: []Network{

--- a/core/scheduler/nomad_job.go
+++ b/core/scheduler/nomad_job.go
@@ -136,8 +136,13 @@ type Check struct {
 
 // Config defines a driver/task configuration
 type Config struct {
-	Command string   `json:"command"`
-	Args    []string `json:"args"`
+	NetworkMode string   `json:"network_mode"`
+	Privileged  bool     `json:"privileged"`
+	ForcePull   bool     `json:"force_pull"`
+	Volumes     []string `json:"volumes"`
+	Image       string   `json:"image"`
+	Command     string   `json:"command"`
+	Args        []string `json:"args"`
 }
 
 // NomadJob represents a nomad job
@@ -165,43 +170,48 @@ func NewJob(connectorVersion, id string, count int) *NomadJob {
 			},
 			TaskGroups: []TaskGroup{
 				TaskGroup{
-					Name:  fmt.Sprintf("tskgrp-%s", id),
+					Name:  fmt.Sprintf("cocoon-grp-%s", id),
 					Count: count,
+					Meta: map[string]string{
+						"VERSION":   "dual-docker",
+						"REPO_USER": "ncodes",
+					},
 					Tasks: []Task{
 						Task{
-							Name:   fmt.Sprintf("task-%s", id),
-							Driver: "raw_exec",
+							Name:   "connector",
+							Driver: "docker",
 							Config: Config{
-								Command: "bash",
-								Args:    []string{"runner.sh"},
+								Image:       "${NOMAD_META_REPO_USER}/cocoon-launcher:latest",
+								NetworkMode: "host",
+								Privileged:  true,
+								ForcePull:   true,
+								Volumes:     []string{"/var/run/docker.sock:/var/run/docker.sock"},
+								Command:     "bash",
+								Args:        []string{"/local/runner.sh"},
 							},
 							Env: map[string]string{
-								"CONNECTOR_VERSION":   connectorVersion,
-								"COCOON_ID":           id,
-								"CONTAINER_ID":        id,
-								"COCOON_LINK":         "",
-								"COCOON_CODE_URL":     "",
-								"COCOON_CODE_TAG":     "",
-								"COCOON_CODE_LANG":    "",
-								"COCOON_BUILD_PARAMS": "",
-								"COCOON_DISK_LIMIT":   "",
-								"ALLOC_MEMORY":        "",
-								"ALLOC_CPU_SHARE":     "",
+								"VERSION":               "${NOMAD_META_VERSION}",
+								"COCOON_ID":             id,
+								"COCOON_CODE_URL":       "",
+								"COCOON_CODE_TAG":       "",
+								"COCOON_CODE_LANG":      "",
+								"COCOON_BUILD_PARAMS":   "",
+								"COCOON_LINK":           "",
+								"COCOON_CONTAINER_NAME": "code-${NOMAD_ALLOC_ID}",
+
 								// The name of the connector runner script and a link to the script.
-								// The runner script will fetch and run whatever is found in this environment vars.
+								// The runner script will fetch and run whatever is found in this environment var.
 								"RUN_SCRIPT_NAME": "run-connector.sh",
-								"RUN_SCRIPT_URL":  "https://rawgit.com/ncodes/cocoon/master/scripts/run-connector.sh",
+								"RUN_SCRIPT_URL":  "https://raw.githubusercontent.com/${NOMAD_META_REPO_USER}/cocoon/${NOMAD_META_VERSION}/scripts/run-connector.sh",
 							},
 							Services: []NomadService{
 								NomadService{
-									Name:      fmt.Sprintf("cocoon"),
+									Name:      fmt.Sprintf("cocoons"),
 									Tags:      []string{id},
-									PortLabel: "CONNECTOR_RPC",
+									PortLabel: "RPC",
 								},
 							},
-							Meta: map[string]string{
-								"something": "something",
-							},
+							Meta: map[string]string{},
 							LogConfig: LogConfig{
 								MaxFiles:      10,
 								MaxFileSizeMB: 10,
@@ -209,20 +219,55 @@ func NewJob(connectorVersion, id string, count int) *NomadJob {
 							Templates: []Template{},
 							Artifacts: []Artifact{
 								Artifact{
-									GetterSource: "https://rawgit.com/ncodes/cocoon/master/scripts/runner.sh",
+									GetterSource: "https://raw.githubusercontent.com/${NOMAD_META_REPO_USER}/cocoon/${NOMAD_META_VERSION}/scripts/runner.sh",
 								},
 							},
 							KillTimeout: 10000000000,
 							Resources: Resources{
-								CPU:      20,
-								MemoryMB: 20,
+								CPU:      100,
+								MemoryMB: 512,
+								DiskMB:   800,
 								IOPS:     0,
 								Networks: []Network{
 									Network{
 										MBits: 1,
 										DynamicPorts: []DynamicPort{
-											DynamicPort{Label: "CONNECTOR_RPC"},
-											DynamicPort{Label: "COCOON_RPC"},
+											DynamicPort{Label: "RPC"},
+										},
+									},
+								},
+							},
+							DispatchPayload: DispatchPayload{},
+						},
+						Task{
+							Name:   "code",
+							Driver: "docker",
+							Config: Config{
+								Image:       "${NOMAD_META_REPO_USER}/launch-go:latest",
+								NetworkMode: "bridge",
+								ForcePull:   true,
+								Command:     "bash",
+								Args:        []string{"-c", "echo 'Hello Human. I am alive'; tail -f /dev/null"},
+							},
+							Env:      map[string]string{},
+							Services: []NomadService{},
+							Meta:     map[string]string{},
+							LogConfig: LogConfig{
+								MaxFiles:      10,
+								MaxFileSizeMB: 10,
+							},
+							Templates: []Template{},
+							Artifacts: []Artifact{},
+							Resources: Resources{
+								CPU:      100,
+								MemoryMB: 512,
+								DiskMB:   800,
+								IOPS:     0,
+								Networks: []Network{
+									Network{
+										MBits: 1,
+										DynamicPorts: []DynamicPort{
+											DynamicPort{Label: "RPC"},
 										},
 									},
 								},
@@ -231,8 +276,9 @@ func NewJob(connectorVersion, id string, count int) *NomadJob {
 						},
 					},
 					Resources: Resources{
-						CPU:      20,
-						MemoryMB: 20,
+						CPU:      100,
+						MemoryMB: 512,
+						DiskMB:   800,
 						IOPS:     0,
 						Networks: []Network{},
 					},
@@ -242,7 +288,6 @@ func NewJob(connectorVersion, id string, count int) *NomadJob {
 						Delay:    25000000000,
 						Mode:     "delay",
 					},
-					Meta: map[string]string{},
 				},
 			},
 			Update: Update{

--- a/core/scheduler/nomad_job.go
+++ b/core/scheduler/nomad_job.go
@@ -151,7 +151,7 @@ type NomadJob struct {
 }
 
 // NewJob creates a new job with some default values.
-func NewJob(connectorVersion, id string, count int) *NomadJob {
+func NewJob(version, id string, count int) *NomadJob {
 	return &NomadJob{
 		Job: &Job{
 			Region:      "",
@@ -173,7 +173,7 @@ func NewJob(connectorVersion, id string, count int) *NomadJob {
 					Name:  fmt.Sprintf("cocoon-grp-%s", id),
 					Count: count,
 					Meta: map[string]string{
-						"VERSION":   "dual-docker",
+						"VERSION":   version,
 						"REPO_USER": "ncodes",
 					},
 					Tasks: []Task{

--- a/core/scheduler/nomad_job.go
+++ b/core/scheduler/nomad_job.go
@@ -185,9 +185,12 @@ func NewJob(version, id string, count int) *NomadJob {
 								NetworkMode: "host",
 								Privileged:  true,
 								ForcePull:   true,
-								Volumes:     []string{"/var/run/docker.sock:/var/run/docker.sock"},
-								Command:     "bash",
-								Args:        []string{"/local/runner.sh"},
+								Volumes: []string{
+									"/var/run/docker.sock:/var/run/docker.sock",
+									"/tmp:/tmp",
+								},
+								Command: "bash",
+								Args:    []string{"/local/runner.sh"},
 							},
 							Env: map[string]string{
 								"VERSION":               "${NOMAD_META_VERSION}",

--- a/core/scheduler/nomad_job.go
+++ b/core/scheduler/nomad_job.go
@@ -220,6 +220,7 @@ func NewJob(version, id string, count int) *NomadJob {
 							Artifacts: []Artifact{
 								Artifact{
 									GetterSource: "https://raw.githubusercontent.com/${NOMAD_META_REPO_USER}/cocoon/${NOMAD_META_VERSION}/scripts/runner.sh",
+									RelativeDest: "/local",
 								},
 							},
 							KillTimeout: 10000000000,

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 80ac05fe9bc6d01004ca1b81ad0c0070f9301a1657cfe63701b5527c8990181e
-updated: 2017-04-05T16:44:20.402766974+01:00
+hash: 6cddad3c7b82a36116afbf58bebf264cd75eee196c34013c70118088b5d8e9c5
+updated: 2017-04-11T19:24:32.188566271+01:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
@@ -140,6 +140,8 @@ imports:
   version: c37440a7cf42ac63b919c752ca73a85067e05992
 - name: github.com/pelletier/go-toml
   version: f6e7596e8daafd44dc9e5c208dc73035020c8481
+- name: github.com/pkg/profile
+  version: 1c16f117a3ab788fdf0e334e623b8bccf5679866
 - name: github.com/PuerkitoBio/purell
   version: b938d81255b5473c57635324295cb0fe398c7a58
 - name: github.com/PuerkitoBio/urlesc
@@ -198,7 +200,7 @@ imports:
   - unicode/norm
   - width
 - name: google.golang.org/grpc
-  version: cdee119ee21e61eef7093a41ba148fa83585e143
+  version: 8050b9cbc271307e5a716a9d782803d09b0d6f2d
   subpackages:
   - codes
   - credentials

--- a/glide.yaml
+++ b/glide.yaml
@@ -42,6 +42,8 @@ import:
 - package: gopkg.in/oleiade/lane.v1
   version: ^1.0.0
 - package: github.com/olekukonko/tablewriter
+- package: github.com/pkg/profile
+  version: ^1.2.0
 testImport:
 - package: github.com/smartystreets/goconvey
   version: ^1.6.2

--- a/scripts/cfg/api/api.nomad
+++ b/scripts/cfg/api/api.nomad
@@ -28,6 +28,10 @@ job "api" {
     task "api" {
       driver = "docker"
       
+      meta {
+        VERSION = "dual-docker"
+      }
+      
       config {
         image = "ncodes/cocoon-launcher:latest"
         command = "bash"
@@ -38,7 +42,7 @@ job "api" {
       }
 
       artifact {
-        source = "https://raw.githubusercontent.com/ncodes/cocoon/master/scripts/cfg/api/run.sh"
+        source = "https://raw.githubusercontent.com/ncodes/cocoon/${NOMAD_META_VERSION}/scripts/cfg/api/run.sh"
         destination = "/local/scripts"
       }
 

--- a/scripts/cfg/api/run.sh
+++ b/scripts/cfg/api/run.sh
@@ -5,7 +5,7 @@ mkdir -p $repoParent
 cd $repoParent
 
 # pull cocoon source
-branch="master"
+branch="dual-docker"
 git clone --depth=1 -b $branch https://github.com/ncodes/cocoon
 cd cocoon 
 git checkout $branch

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -32,7 +32,7 @@ job "cocoon" {
         force_pull = true
         image = "ncodes/cocoon-launcher:latest"  
         command = "bash"
-        args = ["-c", "ls /"]
+        args = ["-c", "ls /alloc/"]
       }
       
       env {

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -48,7 +48,7 @@ job "cocoon" {
         COCOON_CODE_TAG = ""
         COCOON_CODE_LANG = "go"
         COCOON_BUILD_PARAMS = "eyAicGtnX21nciI6ICJnbGlkZSIgfQ=="
-        COCOON_CONTAINER_NAME = "${NOMAD_TASK_NAME}-${NOMAD_ALLOC_ID}"
+        COCOON_CONTAINER_NAME = "code-${NOMAD_ALLOC_ID}"
         
         # The name of the connector runner script and a link to the script.
         # The runner script will fetch and run whatever is found in this environment vars.

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -108,7 +108,7 @@ job "cocoon" {
 
       resources {
         cpu    = 500
-        memory = 512
+        memory = 1024
         network {
           mbits = 1
           port "RPC" {}

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -32,7 +32,7 @@ job "cocoon" {
         force_pull = true
         image = "ncodes/cocoon-launcher:latest"  
         command = "bash"
-        args = ["-c", "ls /local"]
+        args = ["/local/runner.sh"]
       }
       
       env {

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -36,6 +36,7 @@ job "cocoon" {
       }
       
       env {
+        VERSION = "dual-docker"
         COCOON_ID = "abc"
         COCOON_CODE_URL = "https://github.com/ncodes/cocoon-example-01"
         COCOON_CODE_TAG = ""

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -36,6 +36,9 @@ job "cocoon" {
         network_mode = "host"
         privileged = true
         force_pull = true
+        volumes = [
+            "/var/run/docker.sock:/var/run/docker.sock"
+        ]
         image = "ncodes/cocoon-launcher:latest"  
         command = "bash"
         args = ["/local/runner.sh"]

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -79,7 +79,7 @@ job "cocoon" {
         force_pull = true
         image = "ncodes/launch-go:latest"  
         command = "bash"
-        args = ["-c", "echo 'Hello Human, I am Alive'; tail -f /dev/null"]
+        args = ["-c", "echo 'Hello Human. I am alive'; tail -f /dev/null"]
       }
 
       logs {

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -4,8 +4,8 @@ job "cocoon" {
   type = "service"
   
   constraint {
-    // attribute = "${attr.kernel.name}"
-    // value     = "linux"
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
   }
   
   update {

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -41,6 +41,7 @@ job "cocoon" {
         COCOON_CODE_TAG = ""
         COCOON_CODE_LANG = "go"
         COCOON_BUILD_PARAMS = "eyAicGtnX21nciI6ICJnbGlkZSIgfQ=="
+        COCOON_CONTAINER_NAME = "${NOMAD_TASK_NAME}-${NOMAD_ALLOC_ID}"
       }
 
       logs {
@@ -53,15 +54,14 @@ job "cocoon" {
         memory = 512
         network {
           mbits = 1
-          port "CONNECTOR_RPC" {}
-          port "COCOON_RPC" {}
+          port "RPC" {}
         }
       }
 
       service {
         name = "connectors"
         tags = []
-        port = "CONNECTOR_RPC"
+        port = "RPC"
         check {
           name     = "alive"
           type     = "tcp"
@@ -69,8 +69,6 @@ job "cocoon" {
           timeout  = "2s"
         }
       }
-    
-    
     }
     
     task "code" {
@@ -81,7 +79,7 @@ job "cocoon" {
         force_pull = true
         image = "ncodes/launch-go:latest"  
         command = "bash"
-        args = ["-c", "echo 'Sleeping'; sleep 3600"]
+        args = ["-c", "echo 'Hello Human, I am Alive'; tail -f /dev/null"]
       }
 
       logs {
@@ -94,6 +92,7 @@ job "cocoon" {
         memory = 512
         network {
           mbits = 1
+          port "RPC" {}
         }
       }
     }

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -12,10 +12,16 @@ job "cocoon" {
     stagger = "10s"
     max_parallel = 1
   }
+  
 
   group "cocoon-grp" {
     count = 1
 
+    meta {
+        VERSION = "dual-docker"
+        REPO_USER = "ncodes"
+    }
+    
     restart {
       attempts = 5
       interval = "30s"
@@ -36,9 +42,9 @@ job "cocoon" {
       }
       
       env {
-        VERSION = "dual-docker"
+        VERSION = "${NOMAD_META_VERSION}"
         COCOON_ID = "abc"
-        COCOON_CODE_URL = "https://github.com/ncodes/cocoon-example-01"
+        COCOON_CODE_URL = "https://github.com/${NOMAD_META_REPO_USER}/cocoon-example-01"
         COCOON_CODE_TAG = ""
         COCOON_CODE_LANG = "go"
         COCOON_BUILD_PARAMS = "eyAicGtnX21nciI6ICJnbGlkZSIgfQ=="
@@ -47,11 +53,11 @@ job "cocoon" {
         # The name of the connector runner script and a link to the script.
         # The runner script will fetch and run whatever is found in this environment vars.
         RUN_SCRIPT_NAME = "run-connector.sh"
-        RUN_SCRIPT_URL = "https://rawgit.com/ncodes/cocoon/master/scripts/run-connector.sh"
+        RUN_SCRIPT_URL = "https://raw.githubusercontent.com/${NOMAD_META_REPO_USER}/cocoon/${NOMAD_META_VERSION}/scripts/run-connector.sh"
       }
 
       artifact {
-        source = "https://rawgit.com/ncodes/cocoon/master/scripts/runner.sh"
+        source = "https://raw.githubusercontent.com/${NOMAD_META_REPO_USER}/cocoon/${NOMAD_META_VERSION}/scripts/runner.sh"
       }
       
       logs {

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -32,7 +32,7 @@ job "cocoon" {
         force_pull = true
         image = "ncodes/cocoon-launcher:latest"  
         command = "bash"
-        args = ["-c", "ls /alloc/"]
+        args = ["-c", "ls /local"]
       }
       
       env {

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -32,7 +32,7 @@ job "cocoon" {
         force_pull = true
         image = "ncodes/cocoon-launcher:latest"  
         command = "bash"
-        args = ["local/runner.sh"]
+        args = ["-c", "ls /"]
       }
       
       env {

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -4,8 +4,8 @@ job "cocoon" {
   type = "service"
   
   constraint {
-    attribute = "${attr.kernel.name}"
-    value     = "linux"
+    // attribute = "${attr.kernel.name}"
+    // value     = "linux"
   }
   
   update {

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -32,7 +32,7 @@ job "cocoon" {
         force_pull = true
         image = "ncodes/cocoon-launcher:latest"  
         command = "bash"
-        args = ["-c", "echo 'Sleeping'; sleep 3600"]
+        args = ["local/runner.sh"]
       }
       
       env {
@@ -42,8 +42,17 @@ job "cocoon" {
         COCOON_CODE_LANG = "go"
         COCOON_BUILD_PARAMS = "eyAicGtnX21nciI6ICJnbGlkZSIgfQ=="
         COCOON_CONTAINER_NAME = "${NOMAD_TASK_NAME}-${NOMAD_ALLOC_ID}"
+        
+        # The name of the connector runner script and a link to the script.
+        # The runner script will fetch and run whatever is found in this environment vars.
+        RUN_SCRIPT_NAME = "run-connector.sh"
+        RUN_SCRIPT_URL = "https://rawgit.com/ncodes/cocoon/master/scripts/run-connector.sh"
       }
 
+      artifact {
+        source = "https://rawgit.com/ncodes/cocoon/master/scripts/runner.sh"
+      }
+      
       logs {
         max_files     = 10
         max_file_size = 10
@@ -51,7 +60,7 @@ job "cocoon" {
 
       resources {
         cpu    = 500
-        memory = 512
+        memory = 1024
         network {
           mbits = 1
           port "RPC" {}

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -1,0 +1,72 @@
+job "cocoon" {
+  datacenters = ["dc1"]
+  region = "global"
+  type = "service"
+  
+  constraint {
+    // attribute = "${attr.kernel.name}"
+    // value     = "linux"
+  }
+  
+  update {
+    stagger = "10s"
+    max_parallel = 1
+  }
+
+  group "cocoon-grp" {
+    count = 1
+
+    restart {
+      attempts = 5
+      interval = "30s"
+      delay = "5s"
+      mode = "delay"
+    }
+ 
+    task "connector" {
+      driver = "docker"
+      
+      config {
+        image = "ncodes/cocoon-launcher:latest"  
+        command = "bash"
+        args = ["-c", "pwd"]
+        network_mode = "host"
+      }
+      
+      env {
+        COCOON_ID = "abc"
+        COCOON_CODE_URL = "https://github.com/ncodes/cocoon-example-01"
+        COCOON_CODE_TAG = ""
+        COCOON_CODE_LANG = "go"
+        COCOON_BUILD_PARAMS = "eyAicGtnX21nciI6ICJnbGlkZSIgfQ=="
+      }
+
+      logs {
+        max_files     = 10
+        max_file_size = 10
+      }
+
+      resources {
+        cpu    = 500
+        memory = 512
+        network {
+          mbits = 1
+          port "CONNECTOR_RPC" {}
+          port "COCOON_RPC" {}
+        }
+      }
+
+      service {
+        name = "connectors"
+        tags = []
+        port = "CONNECTOR_RPC"
+        check {
+          name     = "alive"
+          type     = "tcp"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+    }
+  }
+}

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -4,8 +4,8 @@ job "cocoon" {
   type = "service"
   
   constraint {
-    // attribute = "${attr.kernel.name}"
-    // value     = "linux"
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
   }
   
   update {
@@ -27,10 +27,12 @@ job "cocoon" {
       driver = "docker"
       
       config {
+        network_mode = "host"
+        privileged = true
+        force_pull = true
         image = "ncodes/cocoon-launcher:latest"  
         command = "bash"
-        args = ["-c", "pwd"]
-        network_mode = "host"
+        args = ["-c", "echo 'Sleeping'; sleep 3600"]
       }
       
       env {
@@ -65,6 +67,33 @@ job "cocoon" {
           type     = "tcp"
           interval = "10s"
           timeout  = "2s"
+        }
+      }
+    
+    
+    }
+    
+    task "code" {
+      driver = "docker"
+      
+      config {
+        network_mode = "bridge"
+        force_pull = true
+        image = "ncodes/launch-go:latest"  
+        command = "bash"
+        args = ["-c", "echo 'Sleeping'; sleep 3600"]
+      }
+
+      logs {
+        max_files     = 10
+        max_file_size = 10
+      }
+
+      resources {
+        cpu    = 500
+        memory = 512
+        network {
+          mbits = 1
         }
       }
     }

--- a/scripts/cfg/connector/cocoon.nomad
+++ b/scripts/cfg/connector/cocoon.nomad
@@ -39,7 +39,7 @@ job "cocoon" {
         volumes = [
             "/var/run/docker.sock:/var/run/docker.sock"
         ]
-        image = "ncodes/cocoon-launcher:latest"  
+        image = "${NOMAD_META_REPO_USER}/cocoon-launcher:latest"  
         command = "bash"
         args = ["/local/runner.sh"]
       }
@@ -78,7 +78,7 @@ job "cocoon" {
       }
 
       service {
-        name = "connectors"
+        name = "cocoons"
         tags = []
         port = "RPC"
         check {

--- a/scripts/cfg/nomad/client.hcl
+++ b/scripts/cfg/nomad/client.hcl
@@ -8,7 +8,7 @@ client {
     servers = ["127.0.0.1:4647"]
     
     options = {
-        "driver.raw_exec.enable" = "1"
+        "docker.privileged.enabled" = "true"
     }
 }
 

--- a/scripts/cfg/orderer/orderer.nomad
+++ b/scripts/cfg/orderer/orderer.nomad
@@ -24,6 +24,10 @@ job "orderer" {
     ephemeral_disk {
       size = 1024
     }
+    
+     meta {
+        VERSION = "dual-docker"
+    }
 
     task "orderer" {
       driver = "docker"
@@ -38,7 +42,7 @@ job "orderer" {
       }
 
       artifact {
-        source = "https://raw.githubusercontent.com/ncodes/cocoon/master/scripts/cfg/orderer/run.sh"
+        source = "https://raw.githubusercontent.com/ncodes/cocoon/${NOMAD_META_VERSION}/scripts/cfg/orderer/run.sh"
         destination = "/local/scripts"
       }
 

--- a/scripts/cfg/orderer/run.sh
+++ b/scripts/cfg/orderer/run.sh
@@ -8,7 +8,7 @@ mkdir -p $repoParent
 cd $repoParent
 
 # pull cocoon source
-branch="master"
+branch="dual-docker"
 git clone --depth=1 -b $branch https://github.com/ncodes/cocoon
 cd cocoon 
 git checkout $branch

--- a/scripts/run-connector.sh
+++ b/scripts/run-connector.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Run the connector 
 set -e
-echo 'hello here'
+echo "hello here $!"
 # trap terminate signal and pass to cocoon process
 trap 'echo received in here!' SIGTERM SIGINT
 

--- a/scripts/run-connector.sh
+++ b/scripts/run-connector.sh
@@ -6,10 +6,7 @@ set -e
 trap 'kill -TERM $CPID' SIGTERM SIGINT
 
 # Set up go environment
-export GOROOT=/go
-export GOPATH=/gocode
-PATH=$PATH:$GOROOT/bin:$GOPATH/bin
-mkdir -p $GOPATH/bin
+export GOPATH=/go
 
 # Pull cocoon source
 branch=$VERSION

--- a/scripts/run-connector.sh
+++ b/scripts/run-connector.sh
@@ -12,7 +12,7 @@ PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 mkdir -p $GOPATH/bin
 
 # Pull cocoon source
-branch=$CONNECTOR_VERSION
+branch=$VERSION
 repoOwner=github.com/ncodes
 repoOwnerDir=$GOPATH/src/$repoOwner
 mkdir -p $repoOwnerDir

--- a/scripts/run-connector.sh
+++ b/scripts/run-connector.sh
@@ -5,30 +5,35 @@ set -e
 # trap terminate signal and pass to cocoon process
 trap 'echo received in here!' SIGTERM SIGINT
 
+while true
+do
+  tail -f /dev/null & wait ${!}
+done
+
 # Set up go environment
-export GOPATH=/go
+# export GOPATH=/go
 
-# Pull cocoon source
-branch=$VERSION
-repoOwner=github.com/ncodes
-repoOwnerDir=$GOPATH/src/$repoOwner
-mkdir -p $repoOwnerDir
-cd $repoOwnerDir
-printf "> Fetching cocoon source. [branch=$branch] [dest=$repoOwnerDir]\n"
-rm -rf cocoon
-git clone --depth=1 -b $branch https://$repoOwner/cocoon
+# # Pull cocoon source
+# branch=$VERSION
+# repoOwner=github.com/ncodes
+# repoOwnerDir=$GOPATH/src/$repoOwner
+# mkdir -p $repoOwnerDir
+# cd $repoOwnerDir
+# printf "> Fetching cocoon source. [branch=$branch] [dest=$repoOwnerDir]\n"
+# rm -rf cocoon
+# git clone --depth=1 -b $branch https://$repoOwner/cocoon
 
-# build the binary
-printf "> Building cocoon"
-cd cocoon
-rm -rf .glide/ && rm -rf vendor
-glide --debug install
-go build -v -o $GOPATH/bin/cocoon core/main.go
+# # build the binary
+# printf "> Building cocoon"
+# cd cocoon
+# rm -rf .glide/ && rm -rf vendor
+# glide --debug install
+# go build -v -o $GOPATH/bin/cocoon core/main.go
 
-# start connector, store its process id and wait for it.
-printf "Running Cocoon Connector"
-cocoon connector & 
-CPID=$!
-wait $CPID
-wait $CPID
-EXIT_STATUS=$?
+# # start connector, store its process id and wait for it.
+# printf "Running Cocoon Connector"
+# cocoon connector & 
+# CPID=$!
+# wait $CPID
+# wait $CPID
+# EXIT_STATUS=$?

--- a/scripts/run-connector.sh
+++ b/scripts/run-connector.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Run the connector 
 set -e
-
+echo 'hello here'
 # trap terminate signal and pass to cocoon process
 trap 'echo received in here!' SIGTERM SIGINT
 

--- a/scripts/run-connector.sh
+++ b/scripts/run-connector.sh
@@ -28,9 +28,6 @@ rm -rf .glide/ && rm -rf vendor
 glide --debug install
 go build -v -o $GOPATH/bin/cocoon core/main.go
 
-# pull launch-go image
-docker pull ncodes/launch-go:latest 
-
 # start connector, store its process id and wait for it.
 printf "Running Cocoon Connector"
 cocoon connector & 

--- a/scripts/run-connector.sh
+++ b/scripts/run-connector.sh
@@ -3,7 +3,7 @@
 set -e
 
 # trap terminate signal and pass to cocoon process
-trap 'kill -TERM $CPID' SIGTERM SIGINT
+trap 'echo received in here!' SIGTERM SIGINT
 
 # Set up go environment
 export GOPATH=/go

--- a/scripts/run-connector.sh
+++ b/scripts/run-connector.sh
@@ -1,39 +1,44 @@
 #!/bin/bash
 # Run the connector 
 set -e
-echo "hello here $!"
+
+term_connector() {
+    if [ $cpid -ne 0 ]; then
+        kill -SIGTERM "$cpid"
+        wait "$cpid"
+    fi
+    exit 143;
+}
+
 # trap terminate signal and pass to cocoon process
-trap 'echo received in here!' SIGTERM SIGINT
+trap 'kill ${!}; term_connector' SIGTERM SIGINT
+
+# Set up go environment
+export GOPATH=/go
+
+# Pull cocoon source
+branch=$VERSION
+repoOwner=github.com/ncodes
+repoOwnerDir=$GOPATH/src/$repoOwner
+mkdir -p $repoOwnerDir
+cd $repoOwnerDir
+printf "> Fetching cocoon source. [branch=$branch] [dest=$repoOwnerDir]\n"
+rm -rf cocoon
+git clone --depth=1 -b $branch https://$repoOwner/cocoon
+
+# build the binary
+printf "> Building cocoon"
+cd cocoon
+rm -rf .glide/ && rm -rf vendor
+glide --debug install
+go build -v -o $GOPATH/bin/cocoon core/main.go
+
+# start connector, store its process id and wait for it.
+printf "Running Cocoon Connector"
+cocoon connector & 
+cpid=$!
 
 while true
 do
   tail -f /dev/null & wait ${!}
 done
-
-# Set up go environment
-# export GOPATH=/go
-
-# # Pull cocoon source
-# branch=$VERSION
-# repoOwner=github.com/ncodes
-# repoOwnerDir=$GOPATH/src/$repoOwner
-# mkdir -p $repoOwnerDir
-# cd $repoOwnerDir
-# printf "> Fetching cocoon source. [branch=$branch] [dest=$repoOwnerDir]\n"
-# rm -rf cocoon
-# git clone --depth=1 -b $branch https://$repoOwner/cocoon
-
-# # build the binary
-# printf "> Building cocoon"
-# cd cocoon
-# rm -rf .glide/ && rm -rf vendor
-# glide --debug install
-# go build -v -o $GOPATH/bin/cocoon core/main.go
-
-# # start connector, store its process id and wait for it.
-# printf "Running Cocoon Connector"
-# cocoon connector & 
-# CPID=$!
-# wait $CPID
-# wait $CPID
-# EXIT_STATUS=$?

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -3,7 +3,7 @@
 # the connector. 
 set -e
 echo "Runner.sh has started"
-trap 'echo hi' SIGTERM SIGINT
+trap 'echo hi = $PID' SIGTERM SIGINT
 
 # Fetch the script and run it.
 rm -f $RUN_SCRIPT_NAME

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -3,7 +3,7 @@
 # the connector. 
 set -e
 echo "Runner.sh has started"
-trap "echo 'caught the signal'" SIGTERM SIGINT
+trap 'echo caught the signal' SIGTERM SIGINT
 
 # Fetch the script and run it.
 rm -f $RUN_SCRIPT_NAME

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -3,7 +3,7 @@
 # the connector. 
 set -e
 echo "Runner.sh has started"
-trap 'echo hi = $PID' SIGTERM SIGINT
+trap "kill -SIGTERM $PID" SIGTERM SIGINT
 
 # Fetch the script and run it.
 rm -f $RUN_SCRIPT_NAME
@@ -12,5 +12,7 @@ chmod +x $RUN_SCRIPT_NAME
 ./$RUN_SCRIPT_NAME &
 PID=$!
 wait $PID
+echo 'dead'
 wait $PID
+echo 'dead 2'
 EXIT_STATUS=$?

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -3,7 +3,7 @@
 # the connector. 
 set -e
 echo "Runner.sh has started"
-trap 'kill -TERM $PID' SIGTERM SIGINT
+trap 'echo $PID' SIGTERM SIGINT
 
 # Fetch the script and run it.
 rm -f $RUN_SCRIPT_NAME

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -3,7 +3,7 @@
 # the connector. 
 set -e
 echo "Runner.sh has started"
-trap 'echo caught the signal' SIGTERM SIGINT
+trap 'kill -TERM $PID' SIGTERM SIGINT
 
 # Fetch the script and run it.
 rm -f $RUN_SCRIPT_NAME

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -3,16 +3,25 @@
 # the connector. 
 set -e
 echo "Runner.sh has started"
-trap "echo frank $PID" SIGTERM SIGINT
+
+term_handler() {
+    if [ $pid -ne 0 ]; then
+        kill -SIGTERM "$pid"
+        wait "$pid"
+    fi
+    exit 143; 
+}
+
+trap 'kill ${!}; term_handler' SIGTERM SIGINT
 
 # Fetch the script and run it.
 rm -f $RUN_SCRIPT_NAME
 wget $RUN_SCRIPT_URL
 chmod +x $RUN_SCRIPT_NAME
 ./$RUN_SCRIPT_NAME &
-PID=$!
-wait $PID
-echo 'dead'
-wait $PID
-echo 'dead 2'
-EXIT_STATUS=$?
+pid=$!
+
+while true
+do
+  tail -f /dev/null & wait ${!}
+done

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -3,7 +3,7 @@
 # the connector. 
 set -e
 echo "Runner.sh has started"
-trap 'echo $PID' SIGTERM SIGINT
+trap 'echo hi' SIGTERM SIGINT
 
 # Fetch the script and run it.
 rm -f $RUN_SCRIPT_NAME

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -3,7 +3,7 @@
 # the connector. 
 set -e
 echo "Runner.sh has started"
-trap 'kill -TERM $PID' SIGTERM SIGINT
+trap "echo 'caught the signal'" SIGTERM SIGINT
 
 # Fetch the script and run it.
 rm -f $RUN_SCRIPT_NAME

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -3,7 +3,7 @@
 # the connector. 
 set -e
 echo "Runner.sh has started"
-trap "echo hihi $PID" SIGTERM SIGINT
+trap "echo frank $PID" SIGTERM SIGINT
 
 # Fetch the script and run it.
 rm -f $RUN_SCRIPT_NAME

--- a/scripts/runner.sh
+++ b/scripts/runner.sh
@@ -3,7 +3,7 @@
 # the connector. 
 set -e
 echo "Runner.sh has started"
-trap "kill -SIGTERM $PID" SIGTERM SIGINT
+trap "echo hihi $PID" SIGTERM SIGINT
 
 # Fetch the script and run it.
 rm -f $RUN_SCRIPT_NAME


### PR DESCRIPTION
This branch includes changes to how the connector and the cocoon code are started as a unit. Previous builds delegates the starting, stoping and tracking of the cocoon code task to the connector -- The connector was started by the scheduler in a raw_exec driver that provided no allocation/isolation and as such we are left to decided how we share memory and other resource. This was unacceptable.

This branch now delegates the launching of the connector and the cocoon (cocoon code shell or container) to the schedule and injects information into the connector that will allow it access the cocoon container to build and run the cocoon code. 

This updates fixes other issues like glide cache corruption during build stage. 